### PR TITLE
Update Dockerfile to be able to run on M1 Mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,12 @@ COPY --link --from=mwader/static-ffmpeg:6.0 /ffprobe /usr/local/bin/
 COPY --link --from=dependencies /venv /venv
 ARG PATH="/venv/bin:$PATH"
 ENV PATH=${PATH}
+
+# Missing dependencies for arm64
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     apt-get install -y --no-install-recommends libgomp1 libsndfile1; \
     fi
-    
+
 # Non-root user
 RUN useradd -m -s /bin/bash appuser
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,10 @@ COPY --link --from=mwader/static-ffmpeg:6.0 /ffprobe /usr/local/bin/
 COPY --link --from=dependencies /venv /venv
 ARG PATH="/venv/bin:$PATH"
 ENV PATH=${PATH}
-
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    apt-get install -y --no-install-recommends libgomp1 libsndfile1; \
+    fi
+    
 # Non-root user
 RUN useradd -m -s /bin/bash appuser
 USER appuser


### PR DESCRIPTION
I had troubles running the M1 Mac docker images - bc. they don't include libgomp and libsndfile in the runtime container - I've added them and for me that now works locally.

this should fix https://github.com/jim60105/docker-whisperX/issues/20