### PR TITLE
feat: Add 'tl' language alignment model

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -301,6 +301,7 @@ jobs:
           - gl
           - ka
           - lv
+          - tl
         model:
           - tiny
           - base

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -59,6 +59,7 @@ target "build" {
       "gl",
       "ka",
       "lv",
+      "tl",
     ]
   }
 

--- a/load_align_model.py
+++ b/load_align_model.py
@@ -47,6 +47,7 @@ DEFAULT_ALIGN_MODELS_HF = {
     "gl": "ifrz/wav2vec2-large-xlsr-galician",
     "ka": "xsway/wav2vec2-large-xlsr-georgian",
     "lv": "jimregan/wav2vec2-large-xlsr-latvian-cv",
+    "tl": "Khalsuu/filipino-wav2vec2-l-xls-r-300m-official",
 }
 
 # From https://github.com/m-bain/whisperX/issues/189#issuecomment-1523392800


### PR DESCRIPTION
Fixes #57

Add 'tl' language alignment model to the project.

* **load_align_model.py**
  - Add 'tl' to `DEFAULT_ALIGN_MODELS_HF` with value `"Khalsuu/filipino-wav2vec2-l-xls-r-300m-official"`

* **docker-bake.hcl**
  - Add 'tl' to the `LANG` matrix

* **.github/workflows/docker_publish.yml**
  - Add 'tl' to the `LANG` matrix

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jim60105/docker-whisperX/pull/58?shareId=9ed4df83-34c0-40eb-a3b9-cc01e14f6654).