### PR TITLE
feat: Implement Silero VAD preload to ubi.Dockerfile

### DIFF
--- a/ubi.Dockerfile
+++ b/ubi.Dockerfile
@@ -171,8 +171,15 @@ ARG CONFIG_HOME
 ARG XDG_CONFIG_HOME=${CONFIG_HOME}
 ARG HOME="/root"
 
-# Preload vad model
-RUN python3 -c 'from whisperx.vad import load_vad_model; load_vad_model("cpu");'
+# Preload Silero vad model
+RUN python3 <<EOF
+import torch
+torch.hub.load(repo_or_dir='snakers4/silero-vad',
+               model='silero_vad',
+               force_reload=False,
+               onnx=False,
+               trust_repo=True)
+EOF
 
 ARG WHISPER_MODEL
 ENV WHISPER_MODEL=${WHISPER_MODEL}


### PR DESCRIPTION
Fixes #61

Implement Silero VAD preload in `ubi.Dockerfile`.

* Add a section to preload the Silero VAD model using `torch.hub.load` in the `load_whisper` stage.
* Ensure the `load_whisper` stage includes the necessary code to preload the Silero VAD model.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jim60105/docker-whisperX/pull/62?shareId=f50f7c4f-615a-4712-99db-6c56d7aef57e).