### PR TITLE
feat: unify Docker builds and optimize CUDA support for cu124 + libcudnn8

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -171,8 +171,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Setup docker
         id: setup
@@ -214,8 +212,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Setup docker
         id: setup
@@ -316,8 +312,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Setup docker
         id: setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,17 +32,6 @@ WORKDIR /tmp
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
-# Install libcudnn8
-ADD https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/cuda-keyring_1.1-1_all.deb /tmp/cuda-keyring_x86_64.deb
-
-RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
-    --mount=type=cache,id=aptlists-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/lib/apt/lists \
-    dpkg -i cuda-keyring_x86_64.deb && \
-    rm -f cuda-keyring_x86_64.deb && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libcudnn8
-
 ########################################
 # Base stage for arm64
 ########################################
@@ -87,8 +76,8 @@ ENV UV_PYTHON_DOWNLOADS=0
 RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \
     uv venv --system-site-packages /venv && \
     uv pip install --no-deps \
-    torch==2.5.1 \
-    pyannote.audio==3.3.2
+    "torch<2.4.0" \
+    "pyannote.audio==3.3.2"
 
 # Install whisperX dependencies
 RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ WORKDIR /tmp
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,id=aptlists-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
-    libgomp1=12.2.0-14 libsndfile1=1.2.0-1
+    libgomp1 libsndfile1
 
 # Select the base stage by target architecture
 FROM prepare_base_$TARGETARCH$TARGETVARIANT AS base

--- a/ubi.Dockerfile
+++ b/ubi.Dockerfile
@@ -21,7 +21,7 @@ ARG HF_HOME=${CACHE_HOME}/huggingface
 ########################################
 # Python stage for all bases
 ########################################
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS python
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS ubi-python
 
 # RUN mount cache for multi-arch: https://github.com/docker/buildx/issues/549#issuecomment-1788297892
 ARG TARGETARCH
@@ -40,50 +40,36 @@ RUN ln -s /usr/bin/python3.11 /usr/bin/python3 && \
 
 ########################################
 # Base stage for amd64
-# Only install CUDA for amd64
-# https://github.com/jim60105/docker-whisperX/issues/69
 ########################################
-FROM python AS prepare_base_amd64
+FROM ubi-python AS prepare_base_amd64
 
 # RUN mount cache for multi-arch: https://github.com/docker/buildx/issues/549#issuecomment-1788297892
 ARG TARGETARCH
 ARG TARGETVARIANT
 
+WORKDIR /tmp
+
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
-WORKDIR /tmp
-
-ENV CUDA_VERSION=12.6.3
-ENV NV_CUDA_CUDART_VERSION=12.6.77-1
-ENV NVIDIA_REQUIRE_CUDA=cuda>=12.6
-ENV NV_CUDA_COMPAT_PACKAGE=cuda-compat-12-6
-
-# Install CUDA partially
-# https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#network-repo-installation-for-rhel-rocky
-
+# Install libcudnn8
 RUN --mount=type=cache,id=dnf-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/dnf \
     rpm --import https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/D42D0685.pub && \
     curl -o /etc/yum.repos.d/cuda-rhel9.repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && \
     microdnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 && \
     microdnf -y install --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
-    # Installing the whole CUDA typically increases the image size by approximately **8GB**.
-    # To decrease the image size, we opt to install only the necessary libraries.
-    # Here is the package list for your reference: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
-    # !If you experience any related issues, replace the following line with `cuda-12-6` to obtain the complete CUDA package.
-    cuda-cudart-12-6-${NV_CUDA_CUDART_VERSION} ${NV_CUDA_COMPAT_PACKAGE} libcudnn9-cuda-12 libcusparselt0 libcusparse-12-6 cuda-cupti-12-6 libcufft-12-6 libcurand-12-6 libcublas-12-6 libnccl libnvjitlink-12-6 cuda-nvrtc-12-6
-
-ENV PATH="/usr/local/cuda-12.6/bin${PATH:+:${PATH}}"
-ENV LD_LIBRARY_PATH=/venv/lib/python3.11/site-packages/nvidia/cudnn/lib:/usr/local/cuda-12.6/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+    libcudnn8
 
 ########################################
 # Base stage for arm64
 ########################################
-FROM python AS prepare_base_arm64
+FROM ubi-python AS prepare_base_arm64
 
 # RUN mount cache for multi-arch: https://github.com/docker/buildx/issues/549#issuecomment-1788297892
 ARG TARGETARCH
 ARG TARGETVARIANT
+
+WORKDIR /tmp
 
 # Missing dependencies for arm64
 # https://github.com/jim60105/docker-whisperX/issues/14
@@ -95,9 +81,9 @@ RUN --mount=type=cache,id=dnf-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/v
 FROM prepare_base_$TARGETARCH$TARGETVARIANT AS base
 
 ########################################
-# Build stage for amd64
+# Build stage
 ########################################
-FROM base AS prepare_build_amd64
+FROM base AS build
 
 # RUN mount cache for multi-arch: https://github.com/docker/buildx/issues/549#issuecomment-1788297892
 ARG TARGETARCH
@@ -112,13 +98,12 @@ ENV UV_PROJECT_ENVIRONMENT=/venv
 ENV VIRTUAL_ENV=/venv
 ENV UV_LINK_MODE=copy
 ENV UV_PYTHON_DOWNLOADS=0
-ENV UV_INDEX=https://download.pytorch.org/whl/cu126
 
 # Install torch separately as required
 RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \
     uv venv --system-site-packages /venv && \
     uv pip install --no-deps \
-    torch==2.6.0+cu126 \
+    torch==2.5.1 \
     pyannote.audio==3.3.2
 
 # Install whisperX dependencies
@@ -131,49 +116,6 @@ RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/ro
 RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \
     --mount=source=whisperX,target=.,rw \
     uv sync --frozen --no-dev --no-editable
-
-########################################
-# Build stage for arm64
-########################################
-FROM base AS prepare_build_arm64
-
-# RUN mount cache for multi-arch: https://github.com/docker/buildx/issues/549#issuecomment-1788297892
-ARG TARGETARCH
-ARG TARGETVARIANT
-
-WORKDIR /app
-
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-
-ENV UV_PROJECT_ENVIRONMENT=/venv
-ENV VIRTUAL_ENV=/venv
-ENV UV_LINK_MODE=copy
-ENV UV_PYTHON_DOWNLOADS=0
-ENV UV_INDEX=https://download.pytorch.org/whl/cpu
-
-# Install torch separately as required
-RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \
-    uv venv --system-site-packages /venv && \
-    uv pip install --no-deps \
-    torch==2.6.0+cpu \
-    pyannote.audio==3.3.2
-
-# Install whisperX dependencies
-RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \
-    --mount=type=bind,source=whisperX/pyproject.toml,target=pyproject.toml,rw \
-    --mount=type=bind,source=whisperX/uv.lock,target=uv.lock,rw \
-    uv add torch==2.6.0+cpu && \
-    uv sync --frozen --no-dev --no-install-project --no-editable
-
-# Install whisperX project
-RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \
-    --mount=source=whisperX,target=.,rw \
-    uv add torch==2.6.0+cpu && \
-    uv sync --frozen --no-dev --no-editable
-
-# Select the build stage by target architecture
-FROM prepare_build_$TARGETARCH$TARGETVARIANT AS build
 
 ########################################
 # Final stage for no_model

--- a/ubi.Dockerfile
+++ b/ubi.Dockerfile
@@ -52,14 +52,6 @@ WORKDIR /tmp
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
-# Install libcudnn8
-RUN --mount=type=cache,id=dnf-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/dnf \
-    rpm --import https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/D42D0685.pub && \
-    curl -o /etc/yum.repos.d/cuda-rhel9.repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && \
-    microdnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 && \
-    microdnf -y install --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
-    libcudnn8
-
 ########################################
 # Base stage for arm64
 ########################################
@@ -103,8 +95,8 @@ ENV UV_PYTHON_DOWNLOADS=0
 RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \
     uv venv --system-site-packages /venv && \
     uv pip install --no-deps \
-    torch==2.5.1 \
-    pyannote.audio==3.3.2
+    "torch<2.4.0" \
+    "pyannote.audio==3.3.2"
 
 # Install whisperX dependencies
 RUN --mount=type=cache,id=uv-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/uv \


### PR DESCRIPTION
- Switch base images to explicitly use python:3.11-slim-bullseye and ubi-python for better clarity and reproducibility
- Unify build steps: remove separate arm64 and amd64 build stages in favor of a single, architecture-agnostic build stage
- Remove UV_INDEX environment variable and per-architecture torch install logic; torch is now always installed as torch<2.4.0
- Update submodule whisperX to the latest commit