### PR TITLE
security: pin trivy-action to commit SHA (supply chain attack mitigation)

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Run Trivy vulnerability scanner for Python official image
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         with:
           image-ref: "ghcr.io/jim60105/whisperx:no_model"
           vuln-type: "os,library"

--- a/.github/workflows/scan_ubi.yml
+++ b/.github/workflows/scan_ubi.yml
@@ -22,7 +22,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Run Trivy vulnerability scanner for UBI image
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         with:
           image-ref: "ghcr.io/jim60105/whisperx:ubi-no_model"
           vuln-type: "os,library"
@@ -41,7 +41,7 @@ jobs:
           retention-days: 90
 
       - name: Run Trivy vulnerability scanner for UBI image (SARIF)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         if: always()
         with:
           image-ref: "ghcr.io/jim60105/whisperx:ubi-no_model"


### PR DESCRIPTION
## Summary

Hey! Just a heads-up — this PR pins the `aquasecurity/trivy-action` references in the scan workflows from version tags to commit SHAs.

This is related to the [recent supply chain incident](https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise) affecting `aquasecurity/trivy-action`, where most version tags were force-pushed to modified commits on March 19. GitHub's own [security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends pinning actions to full commit SHAs as the safest approach.

## Changes

| File | Before | After |
|---|---|---|
| `scan.yml:25` | `@0.33.1` | `@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8` |
| `scan_ubi.yml:25` | `@0.33.1` | `@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8` |
| `scan_ubi.yml:44` | `@master` | `@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8` |

The SHA `b6643a29fecd7f34b3597bc6acb0a98b03d33ff8` is the original legitimate commit for v0.33.1, verified against the known-good history.

More context in the related issue: #106

Thanks for maintaining this project!